### PR TITLE
add version to example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -27,6 +27,7 @@ const layer = new ZarrLayer({
   map,
   id: "my-layer",
   source: "./example.zarr",
+  version: 'v2',
   variable: "my_array",
   colormap: [[200, 10, 50], [30, 40, 30], [50, 10, 200]],
   vmin: 20,


### PR DESCRIPTION
really cool work here! Thanks for documenting the example setup so well.

I just noticed one issue when trying it - I needed to add `version: 'v2',` so it would go down the v2 path for accessing the example zarr data. 