### PR TITLE
Reuse `tiles` when `selector` updates

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -15,7 +15,7 @@
 <body>
 <div id="map"></div>
 <script type="module">
-import { ZarrLayer } from "https://cdn.jsdelivr.net/npm/zarr-gl@0.2.0/+esm";
+import { ZarrLayer } from "https://cdn.jsdelivr.net/npm/zarr-gl@0.3.0/dist/zarr-gl.js/+esm";
 const map = new maplibregl.Map({
   container: "map",
   style: "https://demotiles.maplibre.org/style.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,9 +174,6 @@ export class ZarrLayer {
 
   async setSelector(selector: Record<string, number>) {
     this.selector = selector;
-    this.tiles = {};
-    await this.prepareTiles();
-    this.getVisibleTiles();
     await this.prefetchTileData();
     this.invalidate();
   }
@@ -187,7 +184,7 @@ export class ZarrLayer {
       const tilekey = tileToKey(tiletuple);
       const tile = this.tiles[tilekey];
       if (tile) {
-        await tile.fetchData();
+        await tile.fetchData(this.selector);
       }
     }
   }
@@ -246,7 +243,6 @@ export class ZarrLayer {
             dimensions,
             dimArrs,
             shape,
-            selector: this.selector,
             z,
             x,
             y,
@@ -260,7 +256,7 @@ export class ZarrLayer {
     lng: number,
     lat: number,
     x: number,
-    y: number,
+    y: number
   ): Promise<number> {
     const zoom = this.maxZoom;
     const tileTuple: TileTuple = [
@@ -273,7 +269,7 @@ export class ZarrLayer {
     if (tile) {
       const [_, shiftX, shiftY] = tileToScale(tileTuple);
       const [xLocal, yLocal] = [x - shiftX, y - shiftY];
-      const data = await tile.fetchData();
+      const data = await tile.fetchData(this.selector);
       const [xIndex, yIndex] = [
         Math.round(xLocal * TILE_WIDTH * 2 ** zoom),
         Math.round(yLocal * TILE_HEIGHT * 2 ** zoom),
@@ -335,12 +331,12 @@ export class ZarrLayer {
     this.frameBuffers.current = mustCreateFramebuffer(
       gl,
       this.canvasWidth,
-      this.canvasHeight,
+      this.canvasHeight
     );
     this.frameBuffers.next = mustCreateFramebuffer(
       gl,
       this.canvasWidth,
-      this.canvasHeight,
+      this.canvasHeight
     );
 
     await this.prepareTiles();
@@ -350,13 +346,13 @@ export class ZarrLayer {
     const renderVertShader = createShader(
       gl,
       gl.VERTEX_SHADER,
-      renderVertexSource,
+      renderVertexSource
     );
 
     const renderFragShader = createShader(
       gl,
       gl.FRAGMENT_SHADER,
-      renderFragmentSource,
+      renderFragmentSource
     );
 
     this.renderProgram = createProgram(gl, renderVertShader, renderFragShader);
@@ -382,12 +378,12 @@ export class ZarrLayer {
       this.frameBuffers.current = mustCreateFramebuffer(
         gl,
         this.canvasWidth,
-        this.canvasHeight,
+        this.canvasHeight
       );
       this.frameBuffers.next = mustCreateFramebuffer(
         gl,
         this.canvasWidth,
-        this.canvasHeight,
+        this.canvasHeight
       );
     }
 
@@ -517,7 +513,7 @@ export class ZarrLayer {
     gl.bufferData(
       gl.ARRAY_BUFFER,
       new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]),
-      gl.STATIC_DRAW,
+      gl.STATIC_DRAW
     );
     gl.enableVertexAttribArray(this.renderVertexLoc);
     gl.vertexAttribPointer(this.renderVertexLoc, 2, gl.FLOAT, false, 0, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,7 +256,7 @@ export class ZarrLayer {
     lng: number,
     lat: number,
     x: number,
-    y: number
+    y: number,
   ): Promise<number> {
     const zoom = this.maxZoom;
     const tileTuple: TileTuple = [
@@ -331,12 +331,12 @@ export class ZarrLayer {
     this.frameBuffers.current = mustCreateFramebuffer(
       gl,
       this.canvasWidth,
-      this.canvasHeight
+      this.canvasHeight,
     );
     this.frameBuffers.next = mustCreateFramebuffer(
       gl,
       this.canvasWidth,
-      this.canvasHeight
+      this.canvasHeight,
     );
 
     await this.prepareTiles();
@@ -346,13 +346,13 @@ export class ZarrLayer {
     const renderVertShader = createShader(
       gl,
       gl.VERTEX_SHADER,
-      renderVertexSource
+      renderVertexSource,
     );
 
     const renderFragShader = createShader(
       gl,
       gl.FRAGMENT_SHADER,
-      renderFragmentSource
+      renderFragmentSource,
     );
 
     this.renderProgram = createProgram(gl, renderVertShader, renderFragShader);
@@ -378,12 +378,12 @@ export class ZarrLayer {
       this.frameBuffers.current = mustCreateFramebuffer(
         gl,
         this.canvasWidth,
-        this.canvasHeight
+        this.canvasHeight,
       );
       this.frameBuffers.next = mustCreateFramebuffer(
         gl,
         this.canvasWidth,
-        this.canvasHeight
+        this.canvasHeight,
       );
     }
 
@@ -513,7 +513,7 @@ export class ZarrLayer {
     gl.bufferData(
       gl.ARRAY_BUFFER,
       new Float32Array([-1, -1, -1, 1, 1, -1, 1, 1]),
-      gl.STATIC_DRAW
+      gl.STATIC_DRAW,
     );
     gl.enableVertexAttribArray(this.renderVertexLoc);
     gl.vertexAttribPointer(this.renderVertexLoc, 2, gl.FLOAT, false, 0, 0);

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -106,7 +106,7 @@ class Tile {
           return null;
         } else {
           const idx = this.dimArrs[d]?.findIndex(
-            (coordinate) => coordinate === selector[d]
+            (coordinate) => coordinate === selector[d],
           );
           if (typeof idx === "undefined") {
             throw new Error("Couldnt extract indices from dimArrs");


### PR DESCRIPTION
👋 so fun to poke around this repo -- really exciting to see how concise the codebase is compared to `@carbonplan/maps`! In order to understand the repo better, I took a stab at cleaning up some performance issues I noticed on https://rainy.rdrn.me/.

This PR:
- Updates the `setSelector()` function so that it no longer reinstantiates all tiles with the new `selector` value.
  - The number of tiles should remain fixed, but the fetched data may need to be updated as with `selector` updates.
- Instead, the `tile.fetchData()` method now accepts the latest `selector` value.
  - I also added chunk-key-based caching to this method so that unnecessary `setSelector` calls are not so costly (see `vmax` adjustment in GIFs below).
- Updates the module import in **example/** to work with the new export location.

## Before
![CleanShot 2025-06-23 at 17 44 03](https://github.com/user-attachments/assets/7c9712b2-d98a-4686-9a81-d1163ed762c3)

## After
![CleanShot 2025-06-23 at 17 43 34](https://github.com/user-attachments/assets/2d623723-573c-4aa1-9f96-1f8ea7aa05c6)
