### PR TITLE
Handle pr number missing when PR from a fork

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -17,18 +17,32 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pr-metadata-*
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: pr-metadata/
+          merge-multiple: false
+      
       - name: Get PR number
         id: pr
         run: |
-          PR_NUMBER=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}" --jq '.pull_requests[0].number')
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
-            echo "Error: Could not determine PR number from workflow run"
+          # Find the pr-metadata directory (will be pr-metadata-{number})
+          METADATA_DIR=$(find pr-metadata -mindepth 1 -maxdepth 1 -type d | head -n 1)
+          if [ -z "$METADATA_DIR" ]; then
+            echo "Error: Could not find PR metadata directory"
+            exit 1
+          fi
+          
+          PR_NUMBER=$(cat "$METADATA_DIR/pr-number.txt")
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Error: Could not determine PR number from metadata"
             exit 1
           fi
           echo "Deploying preview for PR #$PR_NUMBER"
           echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Build library
         run: npm run build
       
+      - name: Save PR metadata
+        run: |
+          mkdir -p pr-metadata
+          echo ${{ github.event.number }} > pr-metadata/pr-number.txt
+      
       - name: Create package.json for preview
         run: |
           cat > dist/package.json << 'EOF'
@@ -44,6 +49,13 @@ jobs:
             }
           }
           EOF
+      
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata-${{ github.event.number }}
+          path: pr-metadata/
+          retention-days: 1
       
       - name: Upload build artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
we just write the PR number out to a file we upload instead. Tested inside of my fork (no cross repo tests :( )