### PR TITLE
Use dimension_names instead of _ARRAY_DIMENSIONS in zarr v3

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -143,7 +143,7 @@ const loadZarrV3 = async (
     res.json(),
   );
 
-  const dimensions = arrayMetadata.attributes._ARRAY_DIMENSIONS as string[];
+  const dimensions = arrayMetadata.dimension_names as string[];
   const shape = arrayMetadata.shape;
   const isSharded = arrayMetadata.codecs[0].name == "sharding_indexed";
   const chunks = isSharded


### PR DESCRIPTION
Closes https://github.com/carderne/zarr-gl/issues/24

This does not resolve issues with zarr v3 support, however, since the zarr-js library doesnt really support v3.

See here: https://github.com/gzuidhof/zarr.js/issues/155

So I will look into migration to zarrita.js instead to drive toward v3 support.